### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    container:
+      image: ghcr.io/hdl/debian-buster/impl:prjtrellis
+    strategy:
+      matrix:
+        include:
+          - board: 'digilent_nexys4ddr'
+            args: '--cpu-variant linux --sys-clk-freq 50e6 --with-ethernet --with-sdcard'
+          - board: 'trellisboard'
+            args: '--cpu-variant linuxq --sys-clk-freq 50e6 --with-ethernet --with-sdcard'
+          - board: 'lambdaconcept_ecpix5'
+            args: '--cpu-variant linuxd --sys-clk-freq 50e6 --with-ethernet --with-sdcard'
+          - board: 'lattice_versa_ecp5'
+            args: '--cpu-variant linuxd --sys-clk-freq 50e6 --with-ethernet'
+    steps:
+      # Checkout Repository
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Install Tools
+      - name: Install Tools
+        run: |
+          apt-get -qy update
+          apt-get -qy install wget build-essential python3 python3-pip verilator libevent-dev \
+            libjson-c-dev device-tree-compiler python3-requests python3-pexpect
+
+      # Install (n)Migen / LiteX / Cores
+      - name: Install LiteX
+        run: |
+          wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
+          python3 litex_setup.py init install --user
+
+      # Install RISC-V GCC
+      - name: Install RISC-V GCC
+        run: |
+          python3 litex_setup.py gcc
+
+      # Build
+      - name: Build for ${{ matrix.board }}
+        run: |
+          export PATH=$PATH:~/.local/bin
+          export PATH=$PATH:$(realpath ../riscv64-*/bin)
+          echo $PATH
+          git clean -dfx
+          ../litex-boards/litex_boards/targets/${{ matrix.board }}.py \
+            --cpu-type rocket \
+            ${{ matrix.args }}
+          ls -lR
+          git status
+
+      # Upload
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.board }}
+          path: build/*/gateware


### PR DESCRIPTION
This adds the groundwork for automatically building bitstreams via GitHub Actions. The artifacts are available for download from the build page: https://github.com/jluebbe/linux-on-litex-rocket/actions/runs/847442335