### PR TITLE
Add dts for arty board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 bin/*
+build/*
+busybox-1.31.0
+initramfs/*
+prog/*
+riscv-pk/*

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ place, building bitstream for each one is a relatively straightforward process.
 variants of the Rocket cpu-type is in the bit width of the point-to-point
 AXI link connecting the CPU and LiteDRAM controller specific to each particular
 board model.
-On `digilent_nexys4ddr` and `digilent_arty`, LiteDRAM has a native
+On `digilent_nexys4ddr`, LiteDRAM has a native
 port width of 64 bits;
 on the `trellisboard`, the native LiteDRAM width is 256 bits; finally, on
-both `lambdaconcept_ecpix5` and `lattice_versa_ecp5`, LiteDRAM is 128 bit wide.
+both `lambdaconcept_ecpix5`, `lattice_versa_ecp5` and `digilent_arty`, LiteDRAM is 128 bit wide.
 
 How to tell what the appropriate port width is on a ***new*** board?
 Right after starting the bitstream build process, watch for output that looks

--- a/README.md
+++ b/README.md
@@ -74,15 +74,17 @@ download [here](https://github.com/litex-hub/linux-on-litex-rocket/issues/1).
 
 ## Building the Gateware (FPGA Bitstream):
 
-The four boards currently tested are `digilent_nexys4ddr`, `trellisboard`,
-`lambdaconcept_ecpix5`, and `lattice_versa_ecp5`. Once all prerequisites are in
+The five boards currently tested are `digilent_nexys4ddr`, `trellisboard`,
+`lambdaconcept_ecpix5`, `lattice_versa_ecp5`, and `digilent_arty`. Once all prerequisites are in
 place, building bitstream for each one is a relatively straightforward process.
 
 ***NOTE 1***: The difference between the `linux`, `linuxd`, and `linuxq`
 variants of the Rocket cpu-type is in the bit width of the point-to-point
 AXI link connecting the CPU and LiteDRAM controller specific to each particular
-board model. On `digilent_nexys4ddr`, LiteDRAM has a native port width of 64
-bits; on the `trellisboard`, the native LiteDRAM width is 256 bits; finally, on
+board model.
+On `digilent_nexys4ddr` and `digilent_arty`, LiteDRAM has a native
+port width of 64 bits;
+on the `trellisboard`, the native LiteDRAM width is 256 bits; finally, on
 both `lambdaconcept_ecpix5` and `lattice_versa_ecp5`, LiteDRAM is 128 bit wide.
 
 How to tell what the appropriate port width is on a ***new*** board?
@@ -199,6 +201,20 @@ assuming the board is connected to a USB port and powered on.
                svf build/lattice_versa_ecp5/gateware/lattice_versa_ecp5.svf; exit'
    ```
 
+5. LiteX+Rocket on the `digilent_arty`:
+
+   ```
+   litex-boards/litex_boards/targets/digilent_arty.py --build [--load] \
+      --cpu-type rocket --cpu-variant linuxd --sys-clk-freq 50e6 \
+      --with-ethernet --variant=a7-100
+   ```
+
+   Relies on a proprietary non-FOSS HDL toolchain (Vivado). The design
+   passes timing at 50MHz and Ethernet (and operation under Linux) works.
+   The `a7-35` variant is probably too small to fit Rocket.
+
+   To program the board with a pre-built bitstream file use the `--load` option.
+
 ## Building the Software (`boot.bin`: BusyBox, Linux, and BBL)
 
 To keep things simple, we embed a BusyBox based initial RAM filesystem
@@ -283,12 +299,12 @@ to fit a RocketChip version with a "real" FPU (implemented in gateware).
 
    For now, we provide Device Tree source configurations matching all four
    FPGA development boards for which we know how to build a bitsream:
-   `digilent_nexys4ddr`, `trellisboard`, `lambdaconcept_ecpix5`, and
-   `lattice_versa_ecp5`. The example below uses
+   `digilent_nexys4ddr`, `trellisboard`, `lambdaconcept_ecpix5`,
+   `lattice_versa_ecp5` and `digilent_arty`. The example below uses
    [`nexys4ddr.dts`](conf/nexys4ddr.dts), but feel free
    to replace that with [`trellisboard.dts`](conf/trellisboard.dts),
-   [`ecpix5.dts`](conf/ecpix5.dts),  or
-   [`versa_ecp5.dts`](conf/versa_ecp5.dts), as needed:
+   [`ecpix5.dts`](conf/ecpix5.dts), [`versa_ecp5.dts`](conf/versa_ecp5.dts), 
+   or [`arty.dts`](conf/arty.dts) as needed:
 
    ```
    git clone https://github.com/riscv/riscv-pk

--- a/conf/arty.dts
+++ b/conf/arty.dts
@@ -1,0 +1,111 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "freechips,rocketchip-unknown-dev";
+	model = "freechips,rocketchip-unknown";
+	chosen {
+		bootargs = "earlycon=sbi console=liteuart swiotlb=noforce";
+	};
+	L13: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		timebase-frequency = <1000000>;
+		L6: cpu@0 {
+			clock-frequency = <50000000>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <4096>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <4>;
+			device_type = "cpu";
+			hardware-exec-breakpoint-count = <1>;
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <4096>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <4>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L8>;
+			reg = <0x0>;
+			/* FIXME: blatant lie! BBL should s/imac/imafdc/;
+			   https://github.com/riscv/riscv-pk/issues/166 */
+			riscv,isa = "rv64imafdc";
+			riscv,pmpregions = <8>;
+			status = "okay";
+			tlb-split;
+			L4: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L8: memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>; /* 256MB (arty7) */
+	};
+	L12: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "freechips,rocketchip-unknown-soc", "simple-bus";
+		ranges;
+		L2: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L4 3 &L4 7>;
+			reg = <0x2000000 0x10000>;
+			reg-names = "control";
+		};
+		L3: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L4 0x10>;
+			reg = <0x0 0x1000>;
+			reg-names = "control";
+		};
+		L0: error-device@3000 {
+			compatible = "sifive,error0";
+			reg = <0x3000 0x1000>;
+		};
+		L7: external-interrupts {
+			interrupt-parent = <&L1>;
+			interrupts = <1 2 3 4>;
+		};
+		L1: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L4 11 &L4 9>;
+			reg = <0xc000000 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <4>;
+		};
+		L10: rom@10000 {
+			compatible = "sifive,rom0";
+			reg = <0x10000 0x10000>;
+			reg-names = "mem";
+		};
+		soc_ctrl0: soc_controller@12000000 {
+			compatible = "litex,soc-controller";
+			reg = <0x12000000 0xc>;
+		};
+		liteuart0: serial@0x12004000 {
+			compatible = "litex,liteuart";
+			reg = <0x12004000 0x100>;
+			interrupt-parent = <&L1>;
+			interrupts = <1>;
+		};
+		mac0: mac@12001000 {
+			compatible = "litex,liteeth";
+			reg = <0x12001000 0x7c>,
+				<0x12001800 0x0a>,
+				<0x30000000 0x2000>;
+			tx-fifo-depth = <2>;
+			rx-fifo-depth = <2>;
+			interrupt-parent = <&L1>;
+			interrupts = <3>;
+		};
+	};
+};


### PR DESCRIPTION
Successful boot into Linux on the arty board.
litex-hub/linux-on-litex-rocket readme version: 4e82c36
enjoy-digital/litex version: https://github.com/enjoy-digital/litex/commit/bd1463514b32bee13d70fac67e3a4f105e699738
litex-hub/linux version: https://github.com/litex-hub/linux/commit/9dacadb8c086193d5154a506c0a33f818e7bc22a
riscv/riscv-pk version: https://github.com/riscv/riscv-pk/commit/e8e6b3aaee44d43b48164fbd377864c3a682dbd3

Additionally moved all dependencies to .gitignore.
Alternatively we could add the dependencies as submodules so that they are versioned but don't polute the main directory.
```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2021 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Jun  8 2021 18:30:24
 BIOS CRC passed (767cf069)

 Migen git sha1: 3ffd64c
 LiteX git sha1: bd146351

--=============== SoC ==================--
CPU:            RocketRV64[imac] @ 50MHz
BUS:            WISHBONE 32-bit @ 4GiB
CSR:            32-bit data
ROM:            128KiB
SRAM:           8KiB
SDRAM:          262144KiB 16-bit @ 400MT/s (CL-6 CWL-5)

--========== Initialization ============--
Ethernet init...
Initializing SDRAM @0x80000000...
Switching SDRAM to software control.
Write latency calibration:
m0:0 m1:0 
Read leveling:
  m0, b00: |00000000000000000000000000000000| delays: -
  m0, b01: |11111111111111111111111111111000| delays: 14+-14
  m0, b02: |00000000000000000000000000000001| delays: 31+-00
  m0, b03: |00000000000000000000000000000000| delays: -
  m0, b04: |00000000000000000000000000000000| delays: -
  m0, b05: |00000000000000000000000000000000| delays: -
  m0, b06: |00000000000000000000000000000000| delays: -
  m0, b07: |00000000000000000000000000000000| delays: -
  best: m0, b01 delays: 14+-14
  m1, b00: |00000000000000000000000000000000| delays: -
  m1, b01: |11111111111111111111111111111000| delays: 14+-14
  m1, b02: |00000000000000000000000000000011| delays: 31+-01
  m1, b03: |00000000000000000000000000000000| delays: -
  m1, b04: |00000000000000000000000000000000| delays: -
  m1, b05: |00000000000000000000000000000000| delays: -
  m1, b06: |00000000000000000000000000000000| delays: -
  m1, b07: |00000000000000000000000000000000| delays: -
  best: m1, b01 delays: 14+-14
Switching SDRAM to hardware control.
Memtest at 0x00000080000000 (2.0MiB)...
  Write: 0x80000000-0x80200000 2.0MiB     
   Read: 0x80000000-0x80200000 2.0MiB     
Memtest OK
Memspeed at 0x00000080000000 (2.0MiB)...
  Write speed: 22.4MiB/s
   Read speed: 25.7MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
Timeout
Booting from network...
Local IP: 192.168.1.50
Remote IP: 192.168.1.100
Booting from boot.json...
Booting from boot.bin...
Copying boot.bin to 0x00000080000000... (15705408 bytes)
Executing booted program at 0x80000000

--============= Liftoff! ===============--
bbl loader
              vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
                  vvvvvvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrr       vvvvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrr      vvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrr      vvvvvvvvvvvvvvvvvvvvvv  
rrrrrrrrrrrrr       vvvvvvvvvvvvvvvvvvvvvv    
rr                vvvvvvvvvvvvvvvvvvvvvv      
rr            vvvvvvvvvvvvvvvvvvvvvvvv      rr
rrrr      vvvvvvvvvvvvvvvvvvvvvvvvvv      rrrr
rrrrrr      vvvvvvvvvvvvvvvvvvvvvv      rrrrrr
rrrrrrrr      vvvvvvvvvvvvvvvvvv      rrrrrrrr
rrrrrrrrrr      vvvvvvvvvvvvvv      rrrrrrrrrr
rrrrrrrrrrrr      vvvvvvvvvv      rrrrrrrrrrrr
rrrrrrrrrrrrrr      vvvvvv      rrrrrrrrrrrrrr
rrrrrrrrrrrrrrrr      vv      rrrrrrrrrrrrrrrr
rrrrrrrrrrrrrrrrrr          rrrrrrrrrrrrrrrrrr
rrrrrrrrrrrrrrrrrrrr      rrrrrrrrrrrrrrrrrrrr
rrrrrrrrrrrrrrrrrrrrrr  rrrrrrrrrrrrrrrrrrrrrr

       INSTRUCTION SETS WANT TO BE FREE
[    0.000000] Linux version 5.13.0-rc3-173670-g9dacadb8c086 (martin@martin-ThinkPad-T14-Gen-1) (riscv64-unknown-linux-gnu-gcc (GCC) 9.2.0, GNU ld (GNU Binutils) 2.34) #3 Wed Jun 9 01:39:48 CEST 2021
[    0.000000] OF: fdt: Ignoring memory range 0x80000000 - 0x80200000
[    0.000000] Machine model: freechips,rocketchip-unknown
[    0.000000] earlycon: sbi0 at I/O port 0x0 (options '')
[    0.000000] printk: bootconsole [sbi0] enabled
[    0.000000] efi: UEFI not found.
[    0.000000] Zone ranges:
[    0.000000]   DMA32    [mem 0x0000000080200000-0x000000008fffffff]
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000080200000-0x000000008fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000080200000-0x000000008fffffff]
[    0.000000] On node 0 totalpages: 65024
[    0.000000]   DMA32 zone: 1016 pages used for memmap
[    0.000000]   DMA32 zone: 0 pages reserved
[    0.000000]   DMA32 zone: 65024 pages, LIFO batch:15
[    0.000000] SBI specification v0.1 detected
[    0.000000] riscv: ISA extensions acdfim
[    0.000000] riscv: ELF capabilities acdfim
[    0.000000] pcpu-alloc: s0 r0 d32768 u32768 alloc=1*32768
[    0.000000] pcpu-alloc: [0] 0 
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64008
[    0.000000] Kernel command line: earlycon=sbi console=liteuart swiotlb=noforce
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Sorting __ex_table...
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 241216K/260096K available (3810K kernel code, 4060K rwdata, 2048K rodata, 2808K init, 273K bss, 18880K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] riscv-intc: 64 local interrupts mapped
[    0.000000] plic: interrupt-controller@c000000: mapped 4 interrupts with 1 handlers for 2 contexts.
[    0.000000] random: get_random_bytes called from start_kernel+0x3a8/0x574 with crng_init=0
[    0.000000] riscv_timer_init_dt: Registering clocksource cpuid [0] hartid [0]
[    0.000000] clocksource: riscv_clocksource: mask: 0xffffffffffffffff max_cycles: 0x1d854df40, max_idle_ns: 3526361616960 ns
[    0.000023] sched_clock: 64 bits at 1000kHz, resolution 1000ns, wraps every 2199023255500ns
[    0.006379] Console: colour dummy device 128x32
[    0.008478] Calibrating delay loop (skipped), value calculated using timer frequency.. 2.00 BogoMIPS (lpj=10000)
[    0.013361] pid_max: default: 32768 minimum: 301
[    0.017686] LSM: Security Framework initializing
[    0.020555] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.023970] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.048963] ASID allocator disabled
[    0.051744] EFI services will not be available.
[    0.057162] devtmpfs: initialized
[    0.081948] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.086667] futex hash table entries: 256 (order: 0, 6144 bytes, linear)
[    0.094785] NET: Registered protocol family 16
[    0.216528] clocksource: Switched to clocksource riscv_clocksource
[    0.348980] NET: Registered protocol family 2
[    0.352493] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.364517] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.368878] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.372943] TCP bind hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.376843] TCP: Hash tables configured (established 2048 bind 2048)
[    0.381008] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.384222] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.389704] NET: Registered protocol family 1
[    0.455898] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.697399] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 254)
[    0.703725] LiteX SoC Controller driver initialized
[    2.015569] 12004000.serial: ttyLXU0 at MMIO 0x0 (irq = 0, base_baud = 0) is a liteuart
[    2.021860] printk: console [liteuart0] enabled
[    2.021860] printk: console [liteuart0] enabled
[    2.026203] printk: bootconsole [sbi0] disabled
[    2.026203] printk: bootconsole [sbi0] disabled
[    2.119785] loop: module loaded
[    2.298596] libphy: Fixed MDIO Bus: probed
[    2.310726] liteeth 12001000.mac eth0: irq 2, mapped at ffffffd004016000
[    2.336334] NET: Registered protocol family 10
[    2.357113] Segment Routing with IPv6
[    2.359740] sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
[    2.373841] NET: Registered protocol family 17
[    2.378515] Warning: unable to open an initial console.
[    2.425549] Freeing unused kernel memory: 2808K
[    2.428160] Run /init as init process
[    2.429507]   with arguments:
[    2.430985]     /init
[    2.432113]   with environment:
[    2.433677]     HOME=/
[    2.434848]     TERM=linux
# uname -a
Linux litex 5.13.0-rc3-173670-g9dacadb8c086 #3 Wed Jun 9 01:39:48 CEST 2021 riscv64 GNU/Linux
# cat /proc/cpuinfo
processor       : 0
hart            : 0
isa             : rv64imafdc
mmu             : sv39
uarch           : sifive,rocket0

# ifconfig -a
eth0      Link encap:Ethernet  HWaddr 52:F7:CF:F9:FA:23  
          BROADCAST MULTICAST  MTU:1500  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
          Interrupt:2 

lo        Link encap:Local Loopback  
          LOOPBACK  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

sit0      Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-01-00-00-00-00-00-00-00-00-00  
          NOARP  MTU:1480  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

# ifconfig eth0 up
# udhcpc -i eth0
udhcpc: started, v1.31.0
udhcpc: sending discover
udhcpc: sending select for 192.168.0.102
udhcpc: lease of 192.168.0.102 obtained, lease time 7200
# ifconfig
eth0      Link encap:Ethernet  HWaddr 52:F7:CF:F9:FA:23  
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:36 errors:0 dropped:0 overruns:0 frame:0
          TX packets:10 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:11619 (11.3 KiB)  TX bytes:0 (0.0 B)
          Interrupt:2 

#
``