### PR TITLE
[WIP] Add dts for ulx3s board

### DIFF
--- a/conf/ulx3s.dts
+++ b/conf/ulx3s.dts
@@ -1,0 +1,112 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "freechips,rocketchip-unknown-dev";
+	model = "freechips,rocketchip-unknown";
+	chosen {
+		bootargs = "earlycon=sbi console=liteuart swiotlb=noforce";
+	};
+	L13: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		timebase-frequency = <1000000>;
+		L6: cpu@0 {
+			clock-frequency = <50000000>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <4096>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <4>;
+			device_type = "cpu";
+			hardware-exec-breakpoint-count = <1>;
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <4096>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <4>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L8>;
+			reg = <0x0>;
+			/* FIXME: blatant lie! BBL should s/imac/imafdc/;
+			   https://github.com/riscv/riscv-pk/issues/166 */
+			riscv,isa = "rv64imafdc";
+			riscv,pmpregions = <8>;
+			status = "okay";
+			tlb-split;
+			L4: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L8: memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 0x02000000>; /* 32MB (ulx3s) */
+	};
+	L12: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "freechips,rocketchip-unknown-soc", "simple-bus";
+		ranges;
+		L2: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L4 3 &L4 7>;
+			reg = <0x2000000 0x10000>;
+			reg-names = "control";
+		};
+		L3: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L4 0x10>;
+			reg = <0x0 0x1000>;
+			reg-names = "control";
+		};
+		L0: error-device@3000 {
+			compatible = "sifive,error0";
+			reg = <0x3000 0x1000>;
+		};
+		L7: external-interrupts {
+			interrupt-parent = <&L1>;
+			interrupts = <1 2 3 4>;
+		};
+		L1: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L4 11 &L4 9>;
+			reg = <0xc000000 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <4>;
+		};
+		L10: rom@10000 {
+			compatible = "sifive,rom0";
+			reg = <0x10000 0x10000>;
+			reg-names = "mem";
+		};
+		soc_ctrl0: soc_controller@12000000 {
+			compatible = "litex,soc-controller";
+			reg = <0x12000000 0xc>;
+		};
+		liteuart0: serial@12005000 {
+			compatible = "litex,liteuart";
+			reg = <0x12005000 0x100>;
+			interrupt-parent = <&L1>;
+			interrupts = <1>;
+		};
+		mmc0: mmc@12003800 {
+			compatible = "litex,mmc";
+			reg = <0x12003800 0x100>,
+				<0x12002000 0x100>,
+				<0x12001800 0x100>,
+				<0x12003000 0x100>,
+				<0x12002800 0x100>;
+			bus-width = <0x04>;
+			interrupt-parent = <&L1>;
+			interrupts = <4>;
+		};
+	};
+};


### PR DESCRIPTION
Successful boot into Linux on the ulx3s board.
litex-hub/linux-on-litex-rocket readme version: 4e82c36
enjoy-digital/litex version: enjoy-digital/litex@d5cfe09f
litex-hub/linux version: litex-hub/linux@9dacadb
riscv/riscv-pk version: riscv/riscv-pk@e8e6b3a

```
lxterm /dev/ttyUSB0  --kernel boot-ulx3s.bin --speed 115200 --kernel-adr 0x80000000

        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2021 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Jun  9 2021 11:00:34
 BIOS CRC passed (95337798)

 Migen git sha1: 3ffd64c
 LiteX git sha1: d5cfe09f

--=============== SoC ==================--
CPU:            RocketRV64[imac] @ 50MHz
BUS:            WISHBONE 32-bit @ 4GiB
CSR:            32-bit data
ROM:            128KiB
SRAM:           8KiB
SDRAM:          32768KiB 16-bit @ 50MT/s (CL-2 CWL-2)

--========== Initialization ============--
Initializing SDRAM @0x80000000...
Switching SDRAM to software control.
Switching SDRAM to hardware control.
Memtest at 0x00000080000000 (2.0MiB)...
  Write: 0x80000000-0x80200000 2.0MiB     
   Read: 0x80000000-0x80200000 2.0MiB     
Memtest OK
Memspeed at 0x00000080000000 (2.0MiB)...
  Write speed: 5.9MiB/s
   Read speed: 8.7MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
[LXTERM] Received firmware download request from the device.
[LXTERM] Uploading boot-ulx3s.bin to 0x80000000 (15705408 bytes)...
[LXTERM] Upload complete (9.9KB/s).
[LXTERM] Booting the device.
[LXTERM] Done.
Executing booted program at 0x80000000

--============= Liftoff! ===============--
bbl loader
              vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
                  vvvvvvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrr       vvvvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrr      vvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrrrr    vvvvvvvvvvvvvvvvvvvvvvvv
rrrrrrrrrrrrrrrr      vvvvvvvvvvvvvvvvvvvvvv  
rrrrrrrrrrrrr       vvvvvvvvvvvvvvvvvvvvvv    
rr                vvvvvvvvvvvvvvvvvvvvvv      
rr            vvvvvvvvvvvvvvvvvvvvvvvv      rr
rrrr      vvvvvvvvvvvvvvvvvvvvvvvvvv      rrrr
rrrrrr      vvvvvvvvvvvvvvvvvvvvvv      rrrrrr
rrrrrrrr      vvvvvvvvvvvvvvvvvv      rrrrrrrr
rrrrrrrrrr      vvvvvvvvvvvvvv      rrrrrrrrrr
rrrrrrrrrrrr      vvvvvvvvvv      rrrrrrrrrrrr
rrrrrrrrrrrrrr      vvvvvv      rrrrrrrrrrrrrr
rrrrrrrrrrrrrrrr      vv      rrrrrrrrrrrrrrrr
rrrrrrrrrrrrrrrrrr          rrrrrrrrrrrrrrrrrr
rrrrrrrrrrrrrrrrrrrr      rrrrrrrrrrrrrrrrrrrr
rrrrrrrrrrrrrrrrrrrrrr  rrrrrrrrrrrrrrrrrrrrrr

       INSTRUCTION SETS WANT TO BE FREE
[    0.000000] Linux version 5.13.0-rc3-173670-g9dacadb8c086 (martin@martin-ThinkPad-T14-Gen-1) (riscv64-unknown-linux-gnu-gcc (GCC) 9.2.0, GNU ld (GNU Binutils) 2.34) #3 Wed Jun 9 01:39:48 CEST 2021
[    0.000000] OF: fdt: Ignoring memory range 0x80000000 - 0x80200000
[    0.000000] Machine model: freechips,rocketchip-unknown
[    0.000000] earlycon: sbi0 at I/O port 0x0 (options '')
[    0.000000] printk: bootconsole [sbi0] enabled
[    0.000000] efi: UEFI not found.
[    0.000000] Zone ranges:
[    0.000000]   DMA32    [mem 0x0000000080200000-0x0000000081ffffff]
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000080200000-0x0000000081ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000080200000-0x0000000081ffffff]
[    0.000000] On node 0 totalpages: 7680
[    0.000000]   DMA32 zone: 120 pages used for memmap
[    0.000000]   DMA32 zone: 0 pages reserved
[    0.000000]   DMA32 zone: 7680 pages, LIFO batch:0
[    0.000000] SBI specification v0.1 detected
[    0.000000] riscv: ISA extensions acdfim
[    0.000000] riscv: ELF capabilities acdfim
[    0.000000] pcpu-alloc: s0 r0 d32768 u32768 alloc=1*32768
[    0.000000] pcpu-alloc: [0] 0 
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 7560
[    0.000000] Kernel command line: earlycon=sbi console=liteuart swiotlb=noforce
[    0.000000] Dentry cache hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.000000] Inode-cache hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.000000] Sorting __ex_table...
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 15764K/30720K available (3810K kernel code, 4060K rwdata, 2048K rodata, 2808K init, 273K bss, 14956K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] riscv-intc: 64 local interrupts mapped
[    0.000000] plic: interrupt-controller@c000000: mapped 4 interrupts with 1 handlers for 2 contexts.
[    0.000000] random: get_random_bytes called from start_kernel+0x3a8/0x574 with crng_init=0
[    0.000000] riscv_timer_init_dt: Registering clocksource cpuid [0] hartid [0]
[    0.000000] clocksource: riscv_clocksource: mask: 0xffffffffffffffff max_cycles: 0x1d854df40, max_idle_ns: 3526361616960 ns
[    0.000138] sched_clock: 64 bits at 1000kHz, resolution 1000ns, wraps every 2199023255500ns
[    0.012199] Console: colour dummy device 128x32
[    0.017497] Calibrating delay loop (skipped), value calculated using timer frequency.. 2.00 BogoMIPS (lpj=10000)
[    0.023810] pid_max: default: 32768 minimum: 301
[    0.037649] LSM: Security Framework initializing
[    0.046726] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.052700] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.185512] ASID allocator disabled
[    0.198171] EFI services will not be available.
[    0.223383] devtmpfs: initialized
[    0.369585] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.375911] futex hash table entries: 256 (order: 0, 6144 bytes, linear)
[    0.409295] NET: Registered protocol family 16
[    1.139724] clocksource: Switched to clocksource riscv_clocksource
[    1.992112] NET: Registered protocol family 2
[    2.004179] IP idents hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    2.042543] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    2.048953] TCP established hash table entries: 512 (order: 0, 4096 bytes, linear)
[    2.055578] TCP bind hash table entries: 512 (order: 0, 4096 bytes, linear)
[    2.061697] TCP: Hash tables configured (established 512 bind 512)
[    2.075551] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    2.082202] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    2.099278] NET: Registered protocol family 1
[    2.325527] workingset: timestamp_bits=46 max_order=12 bucket_order=0
[    3.862898] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 254)
[    3.886272] LiteX SoC Controller driver initialized
[   11.157964] 12005000.serial: ttyLXU0 at MMIO 0x0 (irq = 0, base_baud = 0) is a liteuart
[   11.167466] printk: console [liteuart0] enabled
[   11.167466] printk: console [liteuart0] enabled
[   11.174061] printk: bootconsole [sbi0] disabled
[   11.174061] printk: bootconsole [sbi0] disabled
[   11.758181] loop: module loaded
[   12.936462] libphy: Fixed MDIO Bus: probed
[   12.991290] litex-mmc 12003800.mmc: Requested clk_freq=12500000: set to 12500000 via div=4
[   13.133241] NET: Registered protocol family 10
[   13.702927] Command (cmd 8) failed, status 2
[   14.206253] Command (cmd 55) failed, status 2
[   14.709206] Command (cmd 55) failed, status 2
[   15.213420] Command (cmd 55) failed, status 2
[   15.716375] Command (cmd 55) failed, status 2
[   16.219384] Command (cmd 1) failed, status 2
[   16.223741] litex-mmc 12003800.mmc: Requested clk_freq=0: set to 195312 via div=256
[   16.271769] Segment Routing with IPv6
[   16.281140] sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
[   16.352961] NET: Registered protocol family 17
[   16.383924] Warning: unable to open an initial console.
[   16.734559] Freeing unused kernel memory: 2808K
[   16.743476] Run /init as init process
[   16.745760]   with arguments:
[   16.747463]     /init
[   16.748921]   with environment:
[   16.752011]     HOME=/
[   16.753549]     TERM=linux
#
```