### PR TITLE
Adjusted timebase for Arty

### DIFF
--- a/conf/arty.dts
+++ b/conf/arty.dts
@@ -11,7 +11,7 @@
 	L13: cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		timebase-frequency = <1000000>;
+		timebase-frequency = <500000>;
 		L6: cpu@0 {
 			clock-frequency = <50000000>;
 			compatible = "sifive,rocket0", "riscv";


### PR DESCRIPTION
Adjust timebase for the Arty.
Currently the timer of the Arty moves at half of the rate of the wall time. (measured using `uptime`)
This leads to some benchmark results being twice as high as they should be.
@gsomlo This might apply to some other configs as well.