### PR TITLE
Change Linux variant for Rocket CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ assuming the board is connected to a USB port and powered on.
 
    ```
    litex-boards/litex_boards/targets/digilent_nexys4ddr.py --build [--load] \
-      --cpu-type rocket --cpu-variant linux4 --sys-clk-freq 50e6 \
+      --cpu-type rocket --cpu-variant linux --sys-clk-freq 50e6 \
       --with-ethernet --with-sdcard
    ```
 


### PR DESCRIPTION
`linux4` doesn't exist anymore
```bash
ERROR:SoC:linux4 CPU variant not supported, supported are: 
 - full
 - linux
 - medium
 - small
```
`linux` seems to be a good alternative
https://github.com/litex-hub/pythondata-cpu-rocket/blob/master/pythondata_cpu_rocket/verilog/update.sh#L101